### PR TITLE
Made PnP More Robust

### DIFF
--- a/src/MouthPose.cpp
+++ b/src/MouthPose.cpp
@@ -18,6 +18,7 @@ static uint32 betweenEyesPointX, betweenEyesPointY;
 static int indexStomion, indexLeftEyeLid, indexRightEyeLid;
 static cv::Mat rotationVector;
 static cv::Mat translationVector;
+static bool solvedPnP = false;
 static std::unique_ptr<ros::NodeHandle> nh;
 
 static bool mouthOpen;               // store status of mouth being open or closed
@@ -149,8 +150,9 @@ void imageCallback(const sensor_msgs::ImageConstPtr &msg) {
 
       // calculate rotation and translation vector using solvePnP
       try {
-        cv::solvePnPRansac(modelPoints, imagePoints, cameraMatrix, distCoeffs,
-                           rotationVector, translationVector);
+        cv::solvePnP(modelPoints, imagePoints, cameraMatrix, distCoeffs,
+                           rotationVector, translationVector, solvedPnP, cv::SOLVEPNP_ITERATIVE);
+        solvedPnP = true;
       } catch(...) {
         // sometimes solvePnP will return an error, ignore face in that case
         // See: https://github.com/opencv/opencv/pull/19253

--- a/src/MouthPose.cpp
+++ b/src/MouthPose.cpp
@@ -58,6 +58,7 @@ void imageCallback(const sensor_msgs::ImageConstPtr &msg) {
   }
   if (!facePerceptionOn) {
     cv::destroyAllWindows();
+    solvedPnP = false;
     return;
   }
   try {


### PR DESCRIPTION
See https://github.com/personalrobotics/ada_feeding/issues/11 for details. 

Basically, PnPRansac was extremely unstable, and perceiving faces in strange and varying orientations. This is likely because we only use 12 points to align the face, and Ransac randomly subsamples from them. Ransac works well with many points; 12 seems too low. (Note that PnPRansac was first introduced in [this commit](https://github.com/personalrobotics/face_detection/commit/281d5b002e4fb4ea3c47cd757b43e171e838ab86), and I couldn't find documentation as to why.)

This commit reverts PnPRansac to PnP. To further increase stability, it initializes PnP with the output of the previous PnP call.